### PR TITLE
fix: can't show log in website

### DIFF
--- a/Resources/HttpServerDebug.bundle/web/pages/console_log/console_log.js
+++ b/Resources/HttpServerDebug.bundle/web/pages/console_log/console_log.js
@@ -10,7 +10,8 @@ window.onload = function () {
     localStrings = param;
 
     if ('WebSocket' in window) {
-      var ws = new WebSocket('ws://localhost:5555');
+      var host = window.location.host;
+      var ws = new WebSocket('ws://' + host);
       ws.onopen = function () {
         var stateEle = document.getElementById('connection_state');
         stateEle.innerHTML = 'CONNECTED';


### PR DESCRIPTION
Hi there,

I found there is problem that when you click the 'console log' button, the new web page shows nothing but a 'DISCONNECTED'. It turns out that the host name has been hard-coded. This issue is also mentioned by https://github.com/rob2468/HttpServerDebug/issues/5